### PR TITLE
Setting DATABASE_NAME as public.

### DIFF
--- a/app/src/main/java/com/example/android/sunshine/app/data/WeatherDbHelper.java
+++ b/app/src/main/java/com/example/android/sunshine/app/data/WeatherDbHelper.java
@@ -30,7 +30,7 @@ public class WeatherDbHelper extends SQLiteOpenHelper {
     // If you change the database schema, you must increment the database version.
     private static final int DATABASE_VERSION = 2;
 
-    static final String DATABASE_NAME = "weather.db";
+    public static final String DATABASE_NAME = "weather.db";
 
     public WeatherDbHelper(Context context) {
         super(context, DATABASE_NAME, null, DATABASE_VERSION);


### PR DESCRIPTION
In my project I need set WeatherDbHelper.DATABASE_NAME as a public constant to androidTests can work.
